### PR TITLE
Fix webhoook endpoint is not updating some fields

### DIFF
--- a/src/routes/webhook/webhook.controller.spec.ts
+++ b/src/routes/webhook/webhook.controller.spec.ts
@@ -145,8 +145,15 @@ describe('WebhooksController', () => {
         .set('Authorization', 'Basic ' + process.env.ADMIN_WEBHOOK_AUTH)
         .send(mockRequestDto)
         .expect(201);
+
+      expect(res.body.events).toStrictEqual(['SEND_CONFIRMATIONS']);
+
       const publicId = res.body.id;
-      const updated = { ...mockRequestDto, description: 'Updated E2E Webhook' };
+      const updated = {
+        ...mockRequestDto,
+        description: 'Updated E2E Webhook',
+        events: ['SEND_MULTISIG_TXS'],
+      };
 
       res = await request(app.getHttpServer())
         .put(`/webhooks/${publicId}`)
@@ -155,6 +162,7 @@ describe('WebhooksController', () => {
         .expect(200);
 
       expect(res.body.description).toBe('Updated E2E Webhook');
+      expect(res.body.events).toStrictEqual(['SEND_MULTISIG_TXS']);
       expect(res.body.id).toBe(publicId);
     });
     it('GET /webhooks/:id — should return 403', async () => {

--- a/src/routes/webhook/webhook.service.ts
+++ b/src/routes/webhook/webhook.service.ts
@@ -228,11 +228,16 @@ export class WebhookService {
     publicId: string,
     requestData: WebhookRequestDto,
   ): Promise<WebhookPublicDto> {
-    const webhook = await Webhook.findOneBy({ id: publicId });
-    if (webhook == null) {
+    const webhookStored = await Webhook.findOneBy({ id: publicId });
+    if (webhookStored == null) {
       throw new WebhookDoesNotExist();
     }
-    Object.assign(webhook, requestData);
+    const webhookDto = {
+      ...requestData,
+      id: webhookStored.id,
+    };
+    const publicWebhookDto = plainToInstance(WebhookPublicDto, webhookDto);
+    const webhook = Webhook.fromPublicDto(publicWebhookDto);
     const saved = await this.WebHooksRepository.save(webhook);
     return saved.toPublicDto();
   }


### PR DESCRIPTION
# Description
The previous implementation would work if the received object would be an object of database webhook model, because it is not the case is necessary to convert the received public data to a webhook object previously to save it. 