### PR TITLE
fix: Rewrite admin routes in HTML and patch router

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -98,7 +98,12 @@ function installAdminProxyBodyRewrite(app: INestApplication): void {
   };
   const stack = expressApp.router?.stack ?? expressApp._router?.stack;
   const adminLayer = stack?.find((layer) => layer.name === 'admin');
-  if (!adminLayer) return;
+  if (!adminLayer) {
+    console.warn(
+      '[installAdminProxyBodyRewrite] admin layer not found in Express stack — proxy rewriting will not work',
+    );
+    return;
+  }
 
   const originalHandle = adminLayer.handle;
   const reverseProxy = new ReverseProxyMiddleware();

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,8 +8,12 @@ import {
 import { AppModule } from './app.module';
 import { JsonConsoleLogger } from './logging/json-logger';
 import { INestApplication, LogLevel, ValidationPipe } from '@nestjs/common';
-import { Request, Response } from 'express';
-import { getForwardedPrefix } from './middleware/reverse-proxy.middleware';
+import { Request, RequestHandler, Response } from 'express';
+import { wrapAdminResponse } from './middleware/admin-proxy.middleware';
+import {
+  getForwardedPrefix,
+  ReverseProxyMiddleware,
+} from './middleware/reverse-proxy.middleware';
 
 /**
  * Configure swagger for app
@@ -71,6 +75,41 @@ function getLogLevels(): LogLevel[] {
   return all_log_levels.slice(all_log_levels.indexOf(log_level));
 }
 
+/**
+ * `@adminjs/nestjs` mounts its Express router in `onModuleInit` and then
+ * reorders it to the front of the Express stack, so Nest `MiddlewareConsumer`
+ * entries never run for `/admin/*`. We wrap the admin layer's handler after
+ * `app.listen()` with two pieces:
+ *
+ *  - `ReverseProxyMiddleware`: rewrites `Location` headers emitted by
+ *    `res.redirect(...)` so post-login/logout redirects point to the
+ *    externally-visible proxy URL.
+ *  - `wrapAdminResponse`: patches `res.send` so AdminJS's HTML/JSON bodies
+ *    (which hardcode the internal `rootPath`) get rewritten to include the
+ *    proxy prefix.
+ *
+ * Both are no-op when `x-forwarded-prefix` is absent.
+ */
+function installAdminProxyBodyRewrite(app: INestApplication): void {
+  type ExpressLayer = { name?: string; handle: RequestHandler };
+  const expressApp = app.getHttpAdapter().getInstance() as {
+    router?: { stack: ExpressLayer[] };
+    _router?: { stack: ExpressLayer[] };
+  };
+  const stack = expressApp.router?.stack ?? expressApp._router?.stack;
+  const adminLayer = stack?.find((layer) => layer.name === 'admin');
+  if (!adminLayer) return;
+
+  const originalHandle = adminLayer.handle;
+  const reverseProxy = new ReverseProxyMiddleware();
+  adminLayer.handle = (req, res, next) => {
+    reverseProxy.use(req, res, () => {
+      wrapAdminResponse(req, res);
+      originalHandle(req, res, next);
+    });
+  };
+}
+
 async function bootstrap() {
   const app = await NestFactory.create(AppModule, {
     logger:
@@ -86,5 +125,6 @@ async function bootstrap() {
   setupSwagger(app, basePath);
   app.useGlobalPipes(new ValidationPipe());
   await app.listen(3000);
+  installAdminProxyBodyRewrite(app);
 }
 bootstrap();

--- a/src/middleware/admin-proxy.middleware.spec.ts
+++ b/src/middleware/admin-proxy.middleware.spec.ts
@@ -1,0 +1,180 @@
+import { Request, Response } from 'express';
+import { rewriteAdminPaths, wrapAdminResponse } from './admin-proxy.middleware';
+
+function makeRequest(headers: Record<string, string> = {}): Request {
+  return { headers } as unknown as Request;
+}
+
+function makeResponse(): {
+  res: Response;
+  sent: unknown[];
+  headers: Record<string, string | number>;
+} {
+  const state = {
+    sent: [] as unknown[],
+    headers: {} as Record<string, string | number>,
+  };
+  const res = {
+    getHeader: jest.fn((name: string) => state.headers[name.toLowerCase()]),
+    setHeader: jest.fn((name: string, value: string | number) => {
+      state.headers[name.toLowerCase()] = value;
+      return res;
+    }),
+    removeHeader: jest.fn((name: string) => {
+      delete state.headers[name.toLowerCase()];
+    }),
+    send: jest.fn((body: unknown) => {
+      state.sent.push(body);
+      return res;
+    }),
+  } as unknown as Response;
+  return { res, ...state };
+}
+
+// ---------------------------------------------------------------------------
+// rewriteAdminPaths (pure function)
+// ---------------------------------------------------------------------------
+describe('rewriteAdminPaths', () => {
+  const adminRoot = '/admin';
+  const prefix = '/internal/events';
+
+  it('returns body unchanged when prefix is empty', () => {
+    const body = '{"rootPath":"/admin"}';
+    expect(rewriteAdminPaths(body, adminRoot, '')).toBe(body);
+  });
+
+  it('returns body unchanged when adminRoot is empty', () => {
+    const body = '{"rootPath":"/admin"}';
+    expect(rewriteAdminPaths(body, '', prefix)).toBe(body);
+  });
+
+  it('rewrites bare /admin in JSON', () => {
+    const body = '{"rootPath":"/admin","loginPath":"/admin/login"}';
+    const result = rewriteAdminPaths(body, adminRoot, prefix);
+    expect(result).toBe(
+      '{"rootPath":"/internal/events/admin","loginPath":"/internal/events/admin/login"}',
+    );
+  });
+
+  it('rewrites src and href attributes in HTML', () => {
+    const body =
+      '<script src="/admin/frontend/assets/app.bundle.js"></script>' +
+      '<link href="/admin/frontend/assets/style.css">';
+    const result = rewriteAdminPaths(body, adminRoot, prefix);
+    expect(result).toContain(
+      'src="/internal/events/admin/frontend/assets/app.bundle.js"',
+    );
+    expect(result).toContain(
+      'href="/internal/events/admin/frontend/assets/style.css"',
+    );
+  });
+
+  it('does not double-prefix already-prefixed occurrences', () => {
+    const body = '"/internal/events/admin/login" and "/admin/login"';
+    const result = rewriteAdminPaths(body, adminRoot, prefix);
+    expect(result).toBe(
+      '"/internal/events/admin/login" and "/internal/events/admin/login"',
+    );
+  });
+
+  it('does not rewrite /administrator or /adminxyz', () => {
+    const body = '"/administrator" "/adminxyz" "/admin/ok"';
+    const result = rewriteAdminPaths(body, adminRoot, prefix);
+    expect(result).toContain('"/administrator"');
+    expect(result).toContain('"/adminxyz"');
+    expect(result).toContain('"/internal/events/admin/ok"');
+  });
+
+  it('is idempotent', () => {
+    const body = '{"rootPath":"/admin"}';
+    const once = rewriteAdminPaths(body, adminRoot, prefix);
+    const twice = rewriteAdminPaths(once, adminRoot, prefix);
+    expect(twice).toBe(once);
+  });
+
+  it('works with URL_BASE_PATH prefix in adminRoot', () => {
+    const root = '/v1/admin';
+    const body = '{"rootPath":"/v1/admin","loginPath":"/v1/admin/login"}';
+    const result = rewriteAdminPaths(body, root, prefix);
+    expect(result).toBe(
+      '{"rootPath":"/internal/events/v1/admin","loginPath":"/internal/events/v1/admin/login"}',
+    );
+  });
+
+  it('rewrites window.REDUX_STATE paths', () => {
+    const body =
+      'window.REDUX_STATE = {"paths":{"rootPath":"/admin","loginPath":"/admin/login","logoutPath":"/admin/logout"}}';
+    const result = rewriteAdminPaths(body, adminRoot, prefix);
+    expect(result).toContain('"rootPath":"/internal/events/admin"');
+    expect(result).toContain('"loginPath":"/internal/events/admin/login"');
+    expect(result).toContain('"logoutPath":"/internal/events/admin/logout"');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// wrapAdminResponse (res.send interceptor)
+// ---------------------------------------------------------------------------
+describe('wrapAdminResponse', () => {
+  it('is a no-op without x-forwarded-prefix', () => {
+    const req = makeRequest();
+    const { res } = makeResponse();
+    const origSend = res.send;
+
+    wrapAdminResponse(req, res);
+
+    expect(res.send).toBe(origSend);
+  });
+
+  it('rewrites string bodies (HTML)', () => {
+    const req = makeRequest({ 'x-forwarded-prefix': '/internal/events' });
+    const { res, sent } = makeResponse();
+
+    wrapAdminResponse(req, res);
+    res.send('<script src="/admin/app.js"></script>');
+
+    expect(sent[0]).toBe(
+      '<script src="/internal/events/admin/app.js"></script>',
+    );
+  });
+
+  it('rewrites string bodies (JSON)', () => {
+    const req = makeRequest({ 'x-forwarded-prefix': '/internal/events' });
+    const { res, sent } = makeResponse();
+
+    wrapAdminResponse(req, res);
+    res.send('{"rootPath":"/admin"}');
+
+    expect(sent[0]).toBe('{"rootPath":"/internal/events/admin"}');
+  });
+
+  it('does not touch non-string bodies', () => {
+    const req = makeRequest({ 'x-forwarded-prefix': '/internal/events' });
+    const { res, sent } = makeResponse();
+
+    wrapAdminResponse(req, res);
+    const buffer = Buffer.from([0x89, 0x50, 0x4e, 0x47]);
+    res.send(buffer);
+
+    expect(sent[0]).toBe(buffer);
+  });
+
+  it('removes stale Content-Length so Express recomputes it', () => {
+    const req = makeRequest({ 'x-forwarded-prefix': '/internal/events' });
+    const { res } = makeResponse();
+
+    wrapAdminResponse(req, res);
+    res.send('/admin/x');
+
+    expect(res.removeHeader).toHaveBeenCalledWith('content-length');
+  });
+
+  it('does not remove Content-Length for non-string bodies', () => {
+    const req = makeRequest({ 'x-forwarded-prefix': '/internal/events' });
+    const { res } = makeResponse();
+
+    wrapAdminResponse(req, res);
+    res.send(Buffer.from('binary'));
+
+    expect(res.removeHeader).not.toHaveBeenCalled();
+  });
+});

--- a/src/middleware/admin-proxy.middleware.ts
+++ b/src/middleware/admin-proxy.middleware.ts
@@ -1,0 +1,50 @@
+import { Request, Response } from 'express';
+import { ADMIN_BASE_PATH } from '../modules/admin/admin.constants';
+import { getForwardedPrefix } from './reverse-proxy.middleware';
+
+function escapeRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Rewrites occurrences of `adminRoot` in `body` so they include the proxy
+ * `prefix`. Idempotent via negative lookbehind. Only matches `adminRoot`
+ * followed by a path-boundary character to avoid rewriting "/administrator".
+ */
+export function rewriteAdminPaths(
+  body: string,
+  adminRoot: string,
+  prefix: string,
+): string {
+  if (!prefix || !adminRoot) return body;
+  const root = escapeRegex(adminRoot);
+  const pfx = escapeRegex(prefix);
+  const re = new RegExp(`(?<!${pfx})${root}(?=[\\/"'\`\\s?#\\\\]|$)`, 'g');
+  return body.replace(re, `${prefix}${adminRoot}`);
+}
+
+/**
+ * Patches `res.send` so string bodies (HTML and JSON produced by AdminJS)
+ * get admin paths rewritten to include the proxy prefix. No-op when
+ * `x-forwarded-prefix` is absent, preserving standalone behaviour.
+ *
+ * Redirects issued via `res.redirect` are handled by the existing
+ * `ReverseProxyMiddleware` (invoked alongside this function), which
+ * intercepts `res.setHeader('Location', ...)` globally.
+ *
+ * Binary assets served via `res.sendFile` are not touched because the
+ * AdminJS JS bundles do not contain hardcoded `/admin` strings — they
+ * read `rootPath` at runtime from the state injected in the HTML shell.
+ */
+export function wrapAdminResponse(req: Request, res: Response): void {
+  const prefix = getForwardedPrefix(req);
+  if (!prefix) return;
+  const origSend = res.send.bind(res);
+  (res.send as unknown) = function patchedSend(body: unknown): Response {
+    if (typeof body === 'string') {
+      body = rewriteAdminPaths(body, ADMIN_BASE_PATH, prefix);
+      res.removeHeader('content-length');
+    }
+    return origSend(body as Parameters<Response['send']>[0]);
+  };
+}

--- a/src/middleware/reverse-proxy.middleware.spec.ts
+++ b/src/middleware/reverse-proxy.middleware.spec.ts
@@ -191,4 +191,56 @@ describe('getForwardedPrefix', () => {
       getForwardedPrefix(makeRequest({ 'x-forwarded-prefix': '/my-service' })),
     ).toBe('/my-service');
   });
+
+  it('accepts multi-segment prefixes with dots and hyphens', () => {
+    expect(
+      getForwardedPrefix(
+        makeRequest({ 'x-forwarded-prefix': '/internal/events-v2.0' }),
+      ),
+    ).toBe('/internal/events-v2.0');
+  });
+
+  it('rejects values with spaces', () => {
+    expect(
+      getForwardedPrefix(makeRequest({ 'x-forwarded-prefix': '/foo bar' })),
+    ).toBe('');
+  });
+
+  it('rejects values with query string characters', () => {
+    expect(
+      getForwardedPrefix(makeRequest({ 'x-forwarded-prefix': '/foo?bar=1' })),
+    ).toBe('');
+  });
+
+  it('rejects double slashes', () => {
+    expect(
+      getForwardedPrefix(makeRequest({ 'x-forwarded-prefix': '//evil' })),
+    ).toBe('');
+  });
+
+  it('rejects values not starting with /', () => {
+    expect(
+      getForwardedPrefix(
+        makeRequest({ 'x-forwarded-prefix': 'javascript:alert(1)' }),
+      ),
+    ).toBe('');
+  });
+
+  it('rejects inline <script> tag', () => {
+    expect(
+      getForwardedPrefix(
+        makeRequest({ 'x-forwarded-prefix': '/foo<script>alert(1)</script>' }),
+      ),
+    ).toBe('');
+  });
+
+  it('rejects encoded script injection (%3Cscript%3E)', () => {
+    expect(
+      getForwardedPrefix(
+        makeRequest({
+          'x-forwarded-prefix': '/foo%3Cscript%3Ealert(1)%3C/script%3E',
+        }),
+      ),
+    ).toBe('');
+  });
 });

--- a/src/middleware/reverse-proxy.middleware.ts
+++ b/src/middleware/reverse-proxy.middleware.ts
@@ -13,7 +13,10 @@ function header(req: Request, name: string): string | undefined {
 export function getForwardedPrefix(req: Request): string {
   const raw = header(req, 'x-forwarded-prefix');
   if (!raw) return '';
-  return raw.replace(/\/+$/, '');
+  const stripped = raw.replace(/\/+$/, '');
+  // Reject values that aren't a safe URL path prefix
+  if (!/^(\/[\w.-]+)+$/.test(stripped)) return '';
+  return stripped;
 }
 
 /**

--- a/src/modules/admin/admin.constants.ts
+++ b/src/modules/admin/admin.constants.ts
@@ -1,0 +1,1 @@
+export const ADMIN_BASE_PATH = (process.env.URL_BASE_PATH || '') + '/admin';

--- a/src/modules/admin/adminjs.ts
+++ b/src/modules/admin/adminjs.ts
@@ -1,5 +1,6 @@
 import { Module } from '@nestjs/common';
 import { Webhook } from '../webhook/repositories/webhook.entity';
+import { ADMIN_BASE_PATH } from './admin.constants';
 import { AuthModule } from './auth/auth.module';
 import { AuthService } from './auth/auth.service';
 
@@ -31,15 +32,14 @@ async function buildAdminJsModule() {
   const { AdminModule } = await (eval(
     `import('@adminjs/nestjs')`,
   ) as Promise<any>);
-  const basePath = (process.env.URL_BASE_PATH || '') + '/admin';
   return AdminModule.createAdminAsync({
     imports: [AuthModule],
     inject: [AuthService],
     useFactory: (authService: AuthService) => ({
       adminJsOptions: {
-        rootPath: basePath,
-        loginPath: basePath + '/login',
-        logoutPath: basePath + '/logout',
+        rootPath: ADMIN_BASE_PATH,
+        loginPath: ADMIN_BASE_PATH + '/login',
+        logoutPath: ADMIN_BASE_PATH + '/logout',
         resources: [Webhook],
       },
       auth: {


### PR DESCRIPTION
## What it solves?

This pull request adds support for running the AdminJS admin panel behind a reverse proxy with a URL prefix. It ensures that all internal links, redirects, and static asset references in the AdminJS interface correctly include the external proxy prefix, fixing issues with broken navigation and redirects when accessed via a subpath. 

The implementation includes middleware to rewrite admin paths in HTML/JSON responses and adjusts configuration to use a consistent base path

The middleware is applied after the NestJS app starts because `@adminjs/nest` moves its routes to the front, preventing the current middlewares from being applied