### PR TITLE
Add missing dependencies for AdminJS

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,5 @@
+# adminjs creates a virtual Babel entry file at the project root to resolve its
+# .babelrc.json at runtime. pnpm strict hoisting prevents Babel from finding
+# adminjs's own babel plugins from that path, so we hoist them to root node_modules.
+public-hoist-pattern[]=@babel/plugin-syntax-import-assertions
+public-hoist-pattern[]=@babel/plugin-syntax-import-attributes

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ ENV NODE_ENV=production
 RUN pnpm run build
 
 # Clean and reinstall only production dependencies
+ENV CI=true
 RUN pnpm prune --prod --ignore-scripts
 
 #


### PR DESCRIPTION
- Fix Dockerfile with `CI=true` to prevent `ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY`
