### PR TITLE
fix: harden auth with constant-time comparison

### DIFF
--- a/src/common/guards/basic-auth.guard.spec.ts
+++ b/src/common/guards/basic-auth.guard.spec.ts
@@ -1,0 +1,45 @@
+import { ExecutionContext, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { AdminWebhookGuard } from './basic-auth.guard';
+
+describe('AdminWebhookGuard', () => {
+  const buildContext = (headers: Record<string, string> = {}) =>
+    ({
+      switchToHttp: () => ({
+        getRequest: () => ({ headers }),
+      }),
+    }) as ExecutionContext;
+
+  it('should deny access and log an error when ADMIN_WEBHOOK_AUTH is unset', () => {
+    const configService = {
+      get: jest.fn().mockReturnValue(''),
+    } as unknown as ConfigService;
+    const guard = new AdminWebhookGuard(configService);
+    const loggerSpy = jest
+      .spyOn(Logger.prototype, 'error')
+      .mockImplementation(() => undefined);
+
+    const result = guard.canActivate(buildContext({ authorization: 'Basic ' }));
+
+    expect(result).toBe(false);
+    expect(loggerSpy).toHaveBeenCalledTimes(1);
+    expect(loggerSpy).toHaveBeenCalledWith(
+      expect.stringContaining('ADMIN_WEBHOOK_AUTH is not set'),
+    );
+
+    loggerSpy.mockRestore();
+  });
+
+  it('should grant access when the authorization header matches the configured token', () => {
+    const configService = {
+      get: jest.fn().mockReturnValue('secret-token'),
+    } as unknown as ConfigService;
+    const guard = new AdminWebhookGuard(configService);
+
+    const result = guard.canActivate(
+      buildContext({ authorization: 'Basic secret-token' }),
+    );
+
+    expect(result).toBe(true);
+  });
+});

--- a/src/common/guards/basic-auth.guard.ts
+++ b/src/common/guards/basic-auth.guard.ts
@@ -1,5 +1,11 @@
-import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
+import {
+  CanActivate,
+  ExecutionContext,
+  Injectable,
+  Logger,
+} from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
+import { safeCompare } from '../utils/safe-compare';
 
 @Injectable()
 export class BasicAuthGuard implements CanActivate {
@@ -10,13 +16,16 @@ export class BasicAuthGuard implements CanActivate {
     const token = this.configService.get('SSE_AUTH_TOKEN', '');
     // If token is not set, authentication is disabled
     return (
-      token === '' || request.headers['authorization'] === `Basic ${token}`
+      token === '' ||
+      safeCompare(request.headers['authorization'], `Basic ${token}`)
     );
   }
 }
 
 @Injectable()
 export class AdminWebhookGuard implements CanActivate {
+  private readonly logger = new Logger(AdminWebhookGuard.name);
+
   constructor(private readonly configService: ConfigService) {}
   /**
    * Guard to protect webhooks endpoint.
@@ -26,6 +35,15 @@ export class AdminWebhookGuard implements CanActivate {
   canActivate(context: ExecutionContext): boolean | Promise<boolean> {
     const request = context.switchToHttp().getRequest();
     const token = this.configService.get('ADMIN_WEBHOOK_AUTH', '');
-    return request.headers['authorization'] === `Basic ${token}`;
+    // Deny access when the token is not configured, otherwise the endpoint
+    // would be reachable with an empty `Basic ` credential.
+    if (token === '') {
+      this.logger.error(
+        'ADMIN_WEBHOOK_AUTH is not set. Webhook administration endpoints are ' +
+          'disabled until it is configured.',
+      );
+      return false;
+    }
+    return safeCompare(request.headers['authorization'], `Basic ${token}`);
   }
 }

--- a/src/common/utils/safe-compare.spec.ts
+++ b/src/common/utils/safe-compare.spec.ts
@@ -1,0 +1,38 @@
+import { safeCompare } from './safe-compare';
+
+describe('safeCompare', () => {
+  it('returns true for identical strings', () => {
+    expect(safeCompare('super-secret-token', 'super-secret-token')).toBe(true);
+  });
+
+  it('returns false for different strings of the same length', () => {
+    expect(safeCompare('aaaa', 'bbbb')).toBe(false);
+  });
+
+  it('returns false for strings of different length', () => {
+    expect(safeCompare('short', 'short-but-longer')).toBe(false);
+  });
+
+  it('treats empty strings as equal', () => {
+    expect(safeCompare('', '')).toBe(true);
+  });
+
+  it('returns false when only one value is empty', () => {
+    expect(safeCompare('', 'non-empty')).toBe(false);
+    expect(safeCompare('non-empty', '')).toBe(false);
+  });
+
+  it('handles multi-byte (unicode) values correctly', () => {
+    expect(safeCompare('pásswörd', 'pásswörd')).toBe(true);
+    // Same character count but different bytes
+    expect(safeCompare('café', 'cafe')).toBe(false);
+  });
+
+  it('returns false for non-string provided values', () => {
+    expect(safeCompare(undefined, 'expected')).toBe(false);
+    expect(safeCompare(null, 'expected')).toBe(false);
+    expect(safeCompare(1234, 'expected')).toBe(false);
+    expect(safeCompare(['expected'], 'expected')).toBe(false);
+    expect(safeCompare({}, 'expected')).toBe(false);
+  });
+});

--- a/src/common/utils/safe-compare.ts
+++ b/src/common/utils/safe-compare.ts
@@ -1,0 +1,24 @@
+import { createHmac, randomBytes, timingSafeEqual } from 'crypto';
+
+// Per-process random key. Comparing HMAC digests instead of the raw values
+// keeps the comparison constant-length (so input length is not leaked through
+// timing) and prevents an attacker from precomputing or correlating digests.
+const HMAC_KEY = randomBytes(32);
+
+function digest(value: string): Buffer {
+  return createHmac('sha256', HMAC_KEY).update(value).digest();
+}
+
+/**
+ * Constant-time comparison of two values. Avoids leaking the expected value
+ * (or its length) through response-timing differences: both inputs are reduced
+ * to fixed-length HMAC digests and compared with `timingSafeEqual`, so the same
+ * amount of work is done regardless of whether the lengths match. Non-string
+ * input (e.g. a missing or array-valued header) compares as a mismatch.
+ */
+export function safeCompare(provided: unknown, expected: string): boolean {
+  if (typeof provided !== 'string') {
+    return false;
+  }
+  return timingSafeEqual(digest(provided), digest(expected));
+}

--- a/src/modules/admin/auth/auth.service.ts
+++ b/src/modules/admin/auth/auth.service.ts
@@ -1,6 +1,6 @@
-import { timingSafeEqual } from 'crypto';
 import { Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
+import { safeCompare } from '../../../common/utils/safe-compare';
 
 @Injectable()
 export class AuthService {
@@ -21,17 +21,13 @@ export class AuthService {
     const email = this.getAdminEmail();
     const password = this.getAdminPassword();
     const adminCredentials = { email, password };
-    const emailBuf = Buffer.from(providedEmail);
-    const storedEmailBuf = Buffer.from(adminCredentials.email);
-    const emailMatch =
-      emailBuf.byteLength === storedEmailBuf.byteLength &&
-      timingSafeEqual(emailBuf, storedEmailBuf);
-
-    const passwordBuf = Buffer.from(providedPassword);
-    const storedPasswordBuf = Buffer.from(adminCredentials.password);
-    const passwordMatch =
-      passwordBuf.byteLength === storedPasswordBuf.byteLength &&
-      timingSafeEqual(passwordBuf, storedPasswordBuf);
+    // Compute both comparisons before combining them so the check does not
+    // short-circuit and leak (via timing) whether the email was correct.
+    const emailMatch = safeCompare(providedEmail, adminCredentials.email);
+    const passwordMatch = safeCompare(
+      providedPassword,
+      adminCredentials.password,
+    );
     if (emailMatch && passwordMatch) {
       return adminCredentials;
     }


### PR DESCRIPTION
- Deny AdminWebhookGuard access when ADMIN_WEBHOOK_AUTH is unset, instead of accepting an empty `Basic ` credential, and log that it must be set.
- Replace timing-unsafe `===` comparisons in BasicAuthGuard and AdminWebhookGuard with a constant-time check.
- Extract shared safeCompare util (timingSafeEqual) and reuse it in the guards and AuthService, removing duplicated comparison logic.
- Add unit tests for safeCompare.