### PR TITLE
perf: optimize webhook dispatch and bound response body size

### DIFF
--- a/src/modules/webhook/webhookDispatcher.service.spec.ts
+++ b/src/modules/webhook/webhookDispatcher.service.spec.ts
@@ -24,7 +24,15 @@ function makeHttpAgentResponse(statusCode: number, data = '') {
   return {
     statusCode,
     headers: {},
-    body: { text: jest.fn().mockResolvedValue(data) },
+    // Mimic undici's BodyReadable as a re-iterable async stream of Buffers so
+    // `readBodyWithLimit` can consume it the same way it does in production.
+    body: {
+      async *[Symbol.asyncIterator]() {
+        if (data) {
+          yield Buffer.from(data);
+        }
+      },
+    },
     trailers: {},
     opaque: null,
     context: {},

--- a/src/modules/webhook/webhookDispatcher.service.spec.ts
+++ b/src/modules/webhook/webhookDispatcher.service.spec.ts
@@ -110,6 +110,21 @@ describe('Webhook service', () => {
     });
   });
 
+  describe('getCachedActiveWebhooksIterator', () => {
+    it('should iterate over the cached webhooks', async () => {
+      const expected: WebhookWithStats[] = [webhookWithStatsFactory()];
+      jest
+        .spyOn(webhookDispatcherService, 'getAllActive')
+        .mockImplementation(async () => expected);
+      // Refresh webhooks list
+      await webhookDispatcherService.refreshWebhookMap();
+
+      const iterator =
+        webhookDispatcherService.getCachedActiveWebhooksIterator();
+      expect(Array.from(iterator)).toEqual(expected);
+    });
+  });
+
   describe('postEveryWebhook', () => {
     it('should not post if webhooks are not defined', async () => {
       const webhooks: Webhook[] = [];

--- a/src/modules/webhook/webhookDispatcher.service.ts
+++ b/src/modules/webhook/webhookDispatcher.service.ts
@@ -14,6 +14,12 @@ export const UNDICI_AGENT = Symbol('UNDICI_AGENT');
 
 const JSON_CONTENT_TYPE = 'application/json';
 
+// Cap how much of a webhook response body we read into memory before logging.
+// A misbehaving or malicious target could otherwise stream an unbounded body.
+const DEFAULT_MAX_RESPONSE_BYTES = 10_000;
+
+type ResponseBody = Dispatcher.ResponseData['body'];
+
 const NO_RESPONSE_CODES = new Set([
   'UND_ERR_CONNECT_TIMEOUT',
   'UND_ERR_HEADERS_TIMEOUT',
@@ -35,6 +41,7 @@ export class WebhookDispatcherService implements OnModuleDestroy {
   private webhookFailureThreshold: number;
   private webhookHealthMinutesWindow: number;
   private autoDisableWebhook: boolean;
+  private webhookMaxResponseBytes: number;
 
   constructor(
     @InjectRepository(Webhook)
@@ -55,6 +62,12 @@ export class WebhookDispatcherService implements OnModuleDestroy {
     // Disabled by default
     this.autoDisableWebhook =
       this.configService.get('WEBHOOK_AUTO_DISABLE') === 'true';
+    this.webhookMaxResponseBytes = Number(
+      this.configService.get(
+        'WEBHOOK_MAX_RESPONSE_BYTES',
+        DEFAULT_MAX_RESPONSE_BYTES,
+      ),
+    );
   }
 
   /**
@@ -116,14 +129,18 @@ export class WebhookDispatcherService implements OnModuleDestroy {
   async postEveryWebhook(
     parsedMessage: TxServiceEvent,
   ): Promise<(WebhookResponse | undefined)[]> {
-    const responses = this.getCachedActiveWebhooks()
-      .filter((webhook) => webhook.isEventRelevant(parsedMessage))
-      .map((webhook) => {
-        this.logger.debug(
-          `Sending ${JSON.stringify(parsedMessage)} to ${webhook.url}`,
-        );
-        return this.postWebhook(parsedMessage, webhook);
-      });
+    // Iterate the cached map directly instead of materializing it into an
+    // array (and then filtering/mapping it) on every incoming event.
+    const responses: Promise<WebhookResponse | undefined>[] = [];
+    for (const webhook of this.webhookMap.values()) {
+      if (!webhook.isEventRelevant(parsedMessage)) {
+        continue;
+      }
+      this.logger.debug(
+        `Sending ${JSON.stringify(parsedMessage)} to ${webhook.url}`,
+      );
+      responses.push(this.postWebhook(parsedMessage, webhook));
+    }
     return Promise.all(responses);
   }
 
@@ -153,6 +170,33 @@ export class WebhookDispatcherService implements OnModuleDestroy {
         ...(httpRequestError ? { httpRequestError } : {}),
       },
     });
+  }
+
+  /**
+   * Reads a webhook response body up to `webhookMaxResponseBytes`, discarding
+   * (and flagging) anything beyond the limit so an oversized response cannot
+   * exhaust memory. The body is only used for logging.
+   */
+  async readBodyWithLimit(body: ResponseBody): Promise<string> {
+    const chunks: Buffer[] = [];
+    let total = 0;
+    let truncated = false;
+
+    for await (const chunk of body) {
+      chunks.push(chunk as Buffer);
+      total += (chunk as Buffer).length;
+      if (total > this.webhookMaxResponseBytes) {
+        truncated = true;
+        // Breaking destroys the underlying stream and stops consuming.
+        break;
+      }
+    }
+
+    const text = Buffer.concat(chunks)
+      .subarray(0, this.webhookMaxResponseBytes)
+      .toString('utf8');
+
+    return truncated ? `${text}… [truncated]` : text;
   }
 
   parseResponseData(responseData: any): string {
@@ -241,7 +285,9 @@ export class WebhookDispatcherService implements OnModuleDestroy {
       );
       const webhookResponse = {
         statusCode: response.statusCode,
-        data: this.parseResponseData(await response.body.text()),
+        data: this.parseResponseData(
+          await this.readBodyWithLimit(response.body),
+        ),
       };
 
       if (

--- a/src/modules/webhook/webhookDispatcher.service.ts
+++ b/src/modules/webhook/webhookDispatcher.service.ts
@@ -126,13 +126,21 @@ export class WebhookDispatcherService implements OnModuleDestroy {
     return Array.from(this.webhookMap.values());
   }
 
+  /**
+   * @returns an iterator over the in-memory stored webhooks, avoiding the array
+   * allocation of {@link getCachedActiveWebhooks} on the hot dispatch path.
+   */
+  getCachedActiveWebhooksIterator(): IterableIterator<WebhookWithStats> {
+    return this.webhookMap.values();
+  }
+
   async postEveryWebhook(
     parsedMessage: TxServiceEvent,
   ): Promise<(WebhookResponse | undefined)[]> {
-    // Iterate the cached map directly instead of materializing it into an
+    // Iterate the cached webhooks lazily instead of materializing them into an
     // array (and then filtering/mapping it) on every incoming event.
     const responses: Promise<WebhookResponse | undefined>[] = [];
-    for (const webhook of this.webhookMap.values()) {
+    for (const webhook of this.getCachedActiveWebhooksIterator()) {
       if (!webhook.isEventRelevant(parsedMessage)) {
         continue;
       }

--- a/test/events.e2e-spec.ts
+++ b/test/events.e2e-spec.ts
@@ -59,9 +59,9 @@ describe('Events handling', () => {
       addresses: ['0x0275FC2adfF11270F3EcC4D2F7Aa0a9784601Ca6'],
       sendSafeCreations: true,
     });
-    const getCachedActiveWebhooksSpy = jest
-      .spyOn(webhookDispatcherService, 'getCachedActiveWebhooks')
-      .mockImplementation(() => [mockedWebhook]);
+    const getCachedActiveWebhooksIteratorSpy = jest
+      .spyOn(webhookDispatcherService, 'getCachedActiveWebhooksIterator')
+      .mockImplementation(() => [mockedWebhook].values());
     const postWebhookResponse: any = {
       data: {},
       status: 200,
@@ -84,7 +84,7 @@ describe('Events handling', () => {
     expect(postEveryWebhookSpy).toHaveBeenCalledTimes(1);
     expect(postEveryWebhookSpy).toHaveBeenCalledWith(msg);
 
-    expect(getCachedActiveWebhooksSpy).toHaveBeenCalledTimes(1);
+    expect(getCachedActiveWebhooksIteratorSpy).toHaveBeenCalledTimes(1);
 
     expect(postWebhookSpy).toHaveBeenCalledTimes(1);
     expect(postWebhookSpy).toHaveBeenCalledWith(msg, mockedWebhook);


### PR DESCRIPTION
- Iterate the cached webhook map directly in postEveryWebhook instead of materializing it into an array and filtering/mapping it on every event.
- Read webhook response bodies up to WEBHOOK_MAX_RESPONSE_BYTES (default 10KB) so a misbehaving or malicious target cannot exhaust memory with an unbounded body; truncated bodies are flagged.
- Update dispatcher spec mock to expose an async-iterable response body.