### PR TITLE
fix: serve AdminJS static assets under pnpm (PLA-1573)

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -9,14 +9,8 @@ import { AppModule } from './app.module';
 import { JsonConsoleLogger } from './logging/json-logger';
 import { INestApplication, LogLevel, ValidationPipe } from '@nestjs/common';
 import { Request, RequestHandler, Response } from 'express';
-import {
-  patchAdminAssetDotfiles,
-  wrapAdminResponse,
-} from './middleware/admin-proxy.middleware';
-import {
-  getForwardedPrefix,
-  ReverseProxyMiddleware,
-} from './middleware/reverse-proxy.middleware';
+import { patchAdminResponse } from './middleware/admin-proxy.middleware';
+import { getForwardedPrefix } from './middleware/reverse-proxy.middleware';
 
 /**
  * Configure swagger for app
@@ -81,24 +75,12 @@ function getLogLevels(): LogLevel[] {
 /**
  * `@adminjs/nestjs` mounts its Express router in `onModuleInit` and then
  * reorders it to the front of the Express stack, so Nest `MiddlewareConsumer`
- * entries never run for `/admin/*`. We wrap the admin layer's handler after
- * `app.listen()` with two pieces:
- *
- *  - `ReverseProxyMiddleware`: rewrites `Location` headers emitted by
- *    `res.redirect(...)` so post-login/logout redirects point to the
- *    externally-visible proxy URL.
- *  - `wrapAdminResponse`: patches `res.send` so AdminJS's HTML/JSON bodies
- *    (which hardcode the internal `rootPath`) get rewritten to include the
- *    proxy prefix.
- *  - `patchAdminAssetDotfiles`: patches `res.sendFile` so AdminJS's static
- *    bundles served from pnpm's `node_modules/.pnpm/...` (a dotfile path) are
- *    not turned into spurious 404s by `send`'s default `dotfiles: 'ignore'`.
- *
- * The first two are no-op when `x-forwarded-prefix` is absent;
- * `patchAdminAssetDotfiles` always runs since the asset paths are dotfiles
- * regardless of any proxy.
+ * entries never run for `/admin/*`. We therefore wrap the admin layer's
+ * handler after `app.listen()` and apply `patchAdminResponse`, which adapts
+ * AdminJS's Location headers, HTML/JSON bodies, and static-asset serving (see
+ * its docs). Proxy-prefix rewrites are no-op without `x-forwarded-prefix`.
  */
-function installAdminProxyBodyRewrite(app: INestApplication): void {
+function installAdminResponsePatch(app: INestApplication): void {
   type ExpressLayer = { name?: string; handle: RequestHandler };
   const expressApp = app.getHttpAdapter().getInstance() as {
     router?: { stack: ExpressLayer[] };
@@ -108,19 +90,15 @@ function installAdminProxyBodyRewrite(app: INestApplication): void {
   const adminLayer = stack?.find((layer) => layer.name === 'admin');
   if (!adminLayer) {
     console.warn(
-      '[installAdminProxyBodyRewrite] admin layer not found in Express stack — proxy rewriting will not work',
+      '[installAdminResponsePatch] admin layer not found in Express stack — admin response patching will not work',
     );
     return;
   }
 
   const originalHandle = adminLayer.handle;
-  const reverseProxy = new ReverseProxyMiddleware();
   adminLayer.handle = (req, res, next) => {
-    reverseProxy.use(req, res, () => {
-      wrapAdminResponse(req, res);
-      patchAdminAssetDotfiles(res);
-      originalHandle(req, res, next);
-    });
+    patchAdminResponse(req, res);
+    originalHandle(req, res, next);
   };
 }
 
@@ -139,6 +117,6 @@ async function bootstrap() {
   setupSwagger(app, basePath);
   app.useGlobalPipes(new ValidationPipe());
   await app.listen(3000);
-  installAdminProxyBodyRewrite(app);
+  installAdminResponsePatch(app);
 }
 bootstrap();

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,7 +9,10 @@ import { AppModule } from './app.module';
 import { JsonConsoleLogger } from './logging/json-logger';
 import { INestApplication, LogLevel, ValidationPipe } from '@nestjs/common';
 import { Request, RequestHandler, Response } from 'express';
-import { wrapAdminResponse } from './middleware/admin-proxy.middleware';
+import {
+  patchAdminAssetDotfiles,
+  wrapAdminResponse,
+} from './middleware/admin-proxy.middleware';
 import {
   getForwardedPrefix,
   ReverseProxyMiddleware,
@@ -87,8 +90,13 @@ function getLogLevels(): LogLevel[] {
  *  - `wrapAdminResponse`: patches `res.send` so AdminJS's HTML/JSON bodies
  *    (which hardcode the internal `rootPath`) get rewritten to include the
  *    proxy prefix.
+ *  - `patchAdminAssetDotfiles`: patches `res.sendFile` so AdminJS's static
+ *    bundles served from pnpm's `node_modules/.pnpm/...` (a dotfile path) are
+ *    not turned into spurious 404s by `send`'s default `dotfiles: 'ignore'`.
  *
- * Both are no-op when `x-forwarded-prefix` is absent.
+ * The first two are no-op when `x-forwarded-prefix` is absent;
+ * `patchAdminAssetDotfiles` always runs since the asset paths are dotfiles
+ * regardless of any proxy.
  */
 function installAdminProxyBodyRewrite(app: INestApplication): void {
   type ExpressLayer = { name?: string; handle: RequestHandler };
@@ -110,6 +118,7 @@ function installAdminProxyBodyRewrite(app: INestApplication): void {
   adminLayer.handle = (req, res, next) => {
     reverseProxy.use(req, res, () => {
       wrapAdminResponse(req, res);
+      patchAdminAssetDotfiles(res);
       originalHandle(req, res, next);
     });
   };

--- a/src/middleware/admin-proxy.middleware.spec.ts
+++ b/src/middleware/admin-proxy.middleware.spec.ts
@@ -1,5 +1,9 @@
 import { Request, Response } from 'express';
-import { rewriteAdminPaths, wrapAdminResponse } from './admin-proxy.middleware';
+import {
+  patchAdminAssetDotfiles,
+  rewriteAdminPaths,
+  wrapAdminResponse,
+} from './admin-proxy.middleware';
 
 function makeRequest(headers: Record<string, string> = {}): Request {
   return { headers } as unknown as Request;
@@ -176,5 +180,66 @@ describe('wrapAdminResponse', () => {
     res.send(Buffer.from('binary'));
 
     expect(res.removeHeader).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// patchAdminAssetDotfiles (res.sendFile interceptor)
+// ---------------------------------------------------------------------------
+describe('patchAdminAssetDotfiles', () => {
+  function makeSendFileResponse(): {
+    res: Response;
+    calls: unknown[][];
+  } {
+    const calls: unknown[][] = [];
+    const res = {
+      sendFile: jest.fn((...args: unknown[]) => {
+        calls.push(args);
+      }),
+    } as unknown as Response;
+    return { res, calls };
+  }
+
+  const pnpmPath =
+    '/app/node_modules/.pnpm/adminjs@7.8.17/node_modules/adminjs/lib/frontend/assets/scripts/app-bundle.development.js';
+
+  it('injects dotfiles:allow when AdminJS calls sendFile with only a path', () => {
+    const { res, calls } = makeSendFileResponse();
+
+    patchAdminAssetDotfiles(res);
+    res.sendFile(pnpmPath);
+
+    expect(calls[0][0]).toBe(pnpmPath);
+    expect(calls[0][1]).toEqual({ dotfiles: 'allow' });
+  });
+
+  it('preserves a callback while injecting dotfiles:allow', () => {
+    const { res, calls } = makeSendFileResponse();
+    const cb = jest.fn();
+
+    patchAdminAssetDotfiles(res);
+    res.sendFile(pnpmPath, cb);
+
+    expect(calls[0][0]).toBe(pnpmPath);
+    expect(calls[0][1]).toEqual({ dotfiles: 'allow' });
+    expect(calls[0][2]).toBe(cb);
+  });
+
+  it('defaults dotfiles but keeps caller-provided options', () => {
+    const { res, calls } = makeSendFileResponse();
+
+    patchAdminAssetDotfiles(res);
+    res.sendFile(pnpmPath, { maxAge: 1000 });
+
+    expect(calls[0][1]).toEqual({ dotfiles: 'allow', maxAge: 1000 });
+  });
+
+  it('does not override an explicit dotfiles option', () => {
+    const { res, calls } = makeSendFileResponse();
+
+    patchAdminAssetDotfiles(res);
+    res.sendFile(pnpmPath, { dotfiles: 'deny' });
+
+    expect(calls[0][1]).toEqual({ dotfiles: 'deny' });
   });
 });

--- a/src/middleware/admin-proxy.middleware.spec.ts
+++ b/src/middleware/admin-proxy.middleware.spec.ts
@@ -1,6 +1,7 @@
 import { Request, Response } from 'express';
 import {
   patchAdminAssetDotfiles,
+  patchAdminResponse,
   rewriteAdminPaths,
   wrapAdminResponse,
 } from './admin-proxy.middleware';
@@ -203,7 +204,7 @@ describe('patchAdminAssetDotfiles', () => {
   const pnpmPath =
     '/app/node_modules/.pnpm/adminjs@7.8.17/node_modules/adminjs/lib/frontend/assets/scripts/app-bundle.development.js';
 
-  it('injects dotfiles:allow when AdminJS calls sendFile with only a path', () => {
+  it('injects dotfiles:allow when AdminJS calls sendFile with a path', () => {
     const { res, calls } = makeSendFileResponse();
 
     patchAdminAssetDotfiles(res);
@@ -212,34 +213,62 @@ describe('patchAdminAssetDotfiles', () => {
     expect(calls[0][0]).toBe(pnpmPath);
     expect(calls[0][1]).toEqual({ dotfiles: 'allow' });
   });
+});
 
-  it('preserves a callback while injecting dotfiles:allow', () => {
-    const { res, calls } = makeSendFileResponse();
-    const cb = jest.fn();
+// ---------------------------------------------------------------------------
+// patchAdminResponse (composes the three response patches)
+// ---------------------------------------------------------------------------
+describe('patchAdminResponse', () => {
+  const pnpmPath =
+    '/app/node_modules/.pnpm/adminjs/node_modules/adminjs/frontend/app.bundle.js';
 
-    patchAdminAssetDotfiles(res);
-    res.sendFile(pnpmPath, cb);
+  function makeFullResponse(): {
+    res: Response;
+    sent: unknown[];
+    sentFiles: unknown[][];
+    headers: Record<string, string | number>;
+  } {
+    const state = {
+      sent: [] as unknown[],
+      sentFiles: [] as unknown[][],
+      headers: {} as Record<string, string | number>,
+    };
+    const res = {
+      setHeader: jest.fn((name: string, value: string | number) => {
+        state.headers[name.toLowerCase()] = value;
+        return res;
+      }),
+      removeHeader: jest.fn(),
+      send: jest.fn((body: unknown) => {
+        state.sent.push(body);
+        return res;
+      }),
+      sendFile: jest.fn((...args: unknown[]) => {
+        state.sentFiles.push(args);
+      }),
+    } as unknown as Response;
+    return { res, ...state };
+  }
 
-    expect(calls[0][0]).toBe(pnpmPath);
-    expect(calls[0][1]).toEqual({ dotfiles: 'allow' });
-    expect(calls[0][2]).toBe(cb);
+  it('patches sendFile dotfiles even without a proxy prefix', () => {
+    const req = makeRequest();
+    const { res, sentFiles } = makeFullResponse();
+
+    patchAdminResponse(req, res);
+    res.sendFile(pnpmPath);
+
+    expect(sentFiles[0]).toEqual([pnpmPath, { dotfiles: 'allow' }]);
   });
 
-  it('defaults dotfiles but keeps caller-provided options', () => {
-    const { res, calls } = makeSendFileResponse();
+  it('rewrites bodies and Location headers when behind a proxy', () => {
+    const req = makeRequest({ 'x-forwarded-prefix': '/internal/events' });
+    const { res, sent, headers } = makeFullResponse();
 
-    patchAdminAssetDotfiles(res);
-    res.sendFile(pnpmPath, { maxAge: 1000 });
+    patchAdminResponse(req, res);
+    res.send('{"rootPath":"/admin"}');
+    res.setHeader('Location', '/admin/login');
 
-    expect(calls[0][1]).toEqual({ dotfiles: 'allow', maxAge: 1000 });
-  });
-
-  it('does not override an explicit dotfiles option', () => {
-    const { res, calls } = makeSendFileResponse();
-
-    patchAdminAssetDotfiles(res);
-    res.sendFile(pnpmPath, { dotfiles: 'deny' });
-
-    expect(calls[0][1]).toEqual({ dotfiles: 'deny' });
+    expect(sent[0]).toBe('{"rootPath":"/internal/events/admin"}');
+    expect(headers['location']).toContain('/internal/events/admin/login');
   });
 });

--- a/src/middleware/admin-proxy.middleware.ts
+++ b/src/middleware/admin-proxy.middleware.ts
@@ -48,3 +48,44 @@ export function wrapAdminResponse(req: Request, res: Response): void {
     return origSend(body as Parameters<Response['send']>[0]);
   };
 }
+
+/**
+ * Patches `res.sendFile` so AdminJS's static frontend bundles are served
+ * instead of 404ing.
+ *
+ * `@adminjs/express` serves its assets with `res.sendFile(path.resolve(src))`
+ * and no options. Under pnpm those assets live in `node_modules/.pnpm/...`,
+ * and the `.pnpm` segment is a dotfile. Express 5's `res.sendFile` delegates
+ * to `send`, whose default `dotfiles: 'ignore'` makes any absolute path
+ * containing a dot-segment resolve to `404 Not Found` — so every AdminJS
+ * bundle (JS/CSS/fonts) fails to load and the admin UI renders blank.
+ *
+ * We force `dotfiles: 'allow'` for the asset paths AdminJS serves. These are
+ * fixed, package-internal files (never user-controlled), so allowing dotfiles
+ * here is safe. The patch is idempotent and a no-op for callers that already
+ * pass explicit `dotfiles` handling.
+ */
+export function patchAdminAssetDotfiles(res: Response): void {
+  type SendFile = Response['sendFile'];
+  const origSendFile = res.sendFile.bind(res) as SendFile;
+  (res.sendFile as unknown) = function patchedSendFile(
+    path: string,
+    optionsOrCallback?: unknown,
+    callback?: unknown,
+  ): void {
+    // sendFile(path) / sendFile(path, callback)
+    if (
+      optionsOrCallback === undefined ||
+      typeof optionsOrCallback === 'function'
+    ) {
+      return (origSendFile as (...a: unknown[]) => void)(
+        path,
+        { dotfiles: 'allow' },
+        optionsOrCallback,
+      );
+    }
+    // sendFile(path, options[, callback]) — default dotfiles unless set
+    const options = { dotfiles: 'allow', ...(optionsOrCallback as object) };
+    return (origSendFile as (...a: unknown[]) => void)(path, options, callback);
+  };
+}

--- a/src/middleware/admin-proxy.middleware.ts
+++ b/src/middleware/admin-proxy.middleware.ts
@@ -1,6 +1,9 @@
 import { Request, Response } from 'express';
 import { ADMIN_BASE_PATH } from '../modules/admin/admin.constants';
-import { getForwardedPrefix } from './reverse-proxy.middleware';
+import {
+  getForwardedPrefix,
+  patchLocationHeader,
+} from './reverse-proxy.middleware';
 
 function escapeRegex(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
@@ -62,30 +65,34 @@ export function wrapAdminResponse(req: Request, res: Response): void {
  *
  * We force `dotfiles: 'allow'` for the asset paths AdminJS serves. These are
  * fixed, package-internal files (never user-controlled), so allowing dotfiles
- * here is safe. The patch is idempotent and a no-op for callers that already
- * pass explicit `dotfiles` handling.
+ * here is safe. `@adminjs/express` only ever calls `sendFile(path)` with a
+ * single argument, so that is the only shape we need to handle.
  */
 export function patchAdminAssetDotfiles(res: Response): void {
-  type SendFile = Response['sendFile'];
-  const origSendFile = res.sendFile.bind(res) as SendFile;
-  (res.sendFile as unknown) = function patchedSendFile(
-    path: string,
-    optionsOrCallback?: unknown,
-    callback?: unknown,
-  ): void {
-    // sendFile(path) / sendFile(path, callback)
-    if (
-      optionsOrCallback === undefined ||
-      typeof optionsOrCallback === 'function'
-    ) {
-      return (origSendFile as (...a: unknown[]) => void)(
-        path,
-        { dotfiles: 'allow' },
-        optionsOrCallback,
-      );
-    }
-    // sendFile(path, options[, callback]) — default dotfiles unless set
-    const options = { dotfiles: 'allow', ...(optionsOrCallback as object) };
-    return (origSendFile as (...a: unknown[]) => void)(path, options, callback);
+  const origSendFile = res.sendFile.bind(res);
+  (res.sendFile as unknown) = (path: string): void => {
+    origSendFile(path, { dotfiles: 'allow' });
   };
+}
+
+/**
+ * Single entry point for every response adaptation AdminJS needs. AdminJS
+ * mounts its own Express router ahead of Nest's middleware, so these are
+ * applied by wrapping the admin layer's handler in `main.ts` rather than via
+ * `MiddlewareConsumer`.
+ *
+ *  - {@link patchLocationHeader}: rewrites `res.redirect` Location headers
+ *    (login/logout) to include the proxy prefix.
+ *  - {@link wrapAdminResponse}: rewrites `res.send` HTML/JSON bodies that
+ *    hardcode the internal `rootPath` to include the proxy prefix.
+ *  - {@link patchAdminAssetDotfiles}: makes `res.sendFile` serve AdminJS's
+ *    pnpm-hosted static bundles instead of 404ing on the `.pnpm` dotfile.
+ *
+ * The first two are no-op without `x-forwarded-prefix`; the dotfile patch
+ * always applies.
+ */
+export function patchAdminResponse(req: Request, res: Response): void {
+  patchLocationHeader(req, res);
+  wrapAdminResponse(req, res);
+  patchAdminAssetDotfiles(res);
 }

--- a/src/middleware/reverse-proxy.middleware.ts
+++ b/src/middleware/reverse-proxy.middleware.ts
@@ -44,42 +44,47 @@ export function getProxyAwareBaseUrl(req: Request): string {
 }
 
 /**
- * Middleware that rewrites Location headers in redirect responses to respect
+ * Patches `res.setHeader` so Location headers in redirect responses respect
  * the x-forwarded-prefix sent by an upstream reverse proxy.
  *
  * Without this, a redirect like `302 Location: /docs` would send the client
- * to the internal path instead of the externally-routed path. With the
- * middleware and a prefix of `/my-service`, the header becomes
- * `Location: /my-service/docs`.
+ * to the internal path instead of the externally-routed path. With a prefix
+ * of `/my-service`, the header becomes `Location: /my-service/docs`.
  *
- * When x-forwarded-prefix is absent or empty the middleware is a no-op and
- * existing behaviour is preserved.
+ * No-op when x-forwarded-prefix is absent or empty, preserving existing
+ * behaviour.
+ */
+export function patchLocationHeader(req: Request, res: Response): void {
+  const prefix = getForwardedPrefix(req);
+  if (!prefix) return;
+
+  const originalSetHeader = res.setHeader.bind(res);
+  const baseUrl = getProxyAwareBaseUrl(req);
+
+  (res.setHeader as unknown) = (
+    name: string,
+    value: string | number | readonly string[],
+  ): Response => {
+    if (
+      name.toLowerCase() === 'location' &&
+      typeof value === 'string' &&
+      value.startsWith('/') &&
+      !value.startsWith(`${prefix}/`)
+    ) {
+      value = `${baseUrl}${value}`;
+    }
+    return originalSetHeader(name, value as string | number | string[]);
+  };
+}
+
+/**
+ * Middleware applying {@link patchLocationHeader} to every request, so
+ * redirects emitted anywhere in the app respect the reverse-proxy prefix.
  */
 @Injectable()
 export class ReverseProxyMiddleware implements NestMiddleware {
   use(req: Request, res: Response, next: NextFunction): void {
-    const prefix = getForwardedPrefix(req);
-
-    if (prefix) {
-      const originalSetHeader = res.setHeader.bind(res);
-      const baseUrl = getProxyAwareBaseUrl(req);
-
-      (res.setHeader as unknown) = (
-        name: string,
-        value: string | number | readonly string[],
-      ): Response => {
-        if (
-          name.toLowerCase() === 'location' &&
-          typeof value === 'string' &&
-          value.startsWith('/') &&
-          !value.startsWith(`${prefix}/`)
-        ) {
-          value = `${baseUrl}${value}`;
-        }
-        return originalSetHeader(name, value as string | number | string[]);
-      };
-    }
-
+    patchLocationHeader(req, res);
     next();
   }
 }


### PR DESCRIPTION
## What

Fixes the AdminJS panel under pnpm and simplifies the admin response-patching middleware.

Resolves PLA-1573.

## Problem

Opening `/admin/login` (e.g. via `pnpm run start:dev`) rendered a blank admin UI and flooded the logs with `NotFoundError: Not Found`. Every AdminJS frontend asset (JS bundles, CSS, fonts) returned a `404`.

## Root cause

The repo migrated to **pnpm** (#497), which lays packages out under `node_modules/.pnpm/...`. The `.pnpm` segment is a **dotfile**.

`@adminjs/express` serves its frontend bundles with `res.sendFile(path.resolve(asset.src))` and **no options**. Express 5's `res.sendFile` delegates to `send@1.2.0`, which — with no `root` option — checks the entire absolute path for dotfiles and applies its default `dotfiles: 'ignore'`. Any path containing a dot-segment (`.pnpm`) resolves to `404 Not Found`.

The asset files exist on disk; they only 404 because of the dotfile rule. The bug did not exist under npm/yarn flat `node_modules`.

## Changes

**Fix** (`fix: serve AdminJS static assets under pnpm`)
- Patch `res.sendFile` on the admin Express layer to inject `{ dotfiles: 'allow' }` for AdminJS's (fixed, package-internal, never user-controlled) asset paths. Runs unconditionally, unlike the proxy-prefix rewrites which are gated on `x-forwarded-prefix`.

**Refactor** (`refactor: simplify AdminJS response patching`) — no behavior change
- Collapse `patchAdminAssetDotfiles` to the single `sendFile(path)` shape `@adminjs/express` act