### PR TITLE
docs: Document trusted field in token webhook events

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Some parameters are common to every event:
   "tokenAddress": "<Ethereum checksummed address>",
   "txHash": "<0x-prefixed-hex-string>",
   "value": "<stringified-int>",
+  "trusted": true | false,
   "chainId": "<stringified-int>"
 }
 ```
@@ -129,6 +130,7 @@ Some parameters are common to every event:
   "tokenAddress": "<Ethereum checksummed address>",
   "txHash": "<0x-prefixed-hex-string>",
   "tokenId": "<stringified-int>",
+  "trusted": true | false,
   "chainId": "<stringified-int>"
 }
 ```


### PR DESCRIPTION
- Related with [PLA-1661](https://linear.app/safe-global/issue/PLA-1661/add-trusted-flag-to-incoming-token-outgoing-token-webhook-events)