### PR TITLE
Document isFailed in EXECUTED_MULTISIG_TRANSACTION webhook

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,10 +66,14 @@ Some parameters are common to every event:
   "to": "<Ethereum checksummed address>",
   "data": "<0x-prefixed-hex-string>" | null,
   "failed": "true" | "false",
+  "isFailed": true | false,
   "txHash": "<0x-prefixed-hex-string>",
   "chainId": "<stringified-int>"
 }
 ```
+
+> **Deprecation:** `failed` is a stringified boolean (`"true"`/`"false"`) kept only for
+> backwards compatibility and will be removed. Use the boolean `isFailed` instead.
 
 ### MultisigTransaction (proposed, not executed)
 


### PR DESCRIPTION
Add the new boolean isFailed field and mark the stringified failed as deprecated.