### PR TITLE
Document timestamp and id fields on events

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,10 +44,15 @@ Some parameters are common to every event:
 - `type`: Event type.
 - `chainId`: Chain id.
 
+Most events also include a `timestamp` (Unix epoch integer, in seconds). Its meaning depends
+on the event (on-chain block time for on-chain events, creation/modification time for off-chain
+ones) and is documented per event below.
+
 ### Multisig Confirmation
 
 ```json
 {
+  "timestamp": "<int>",
   "address": "<Ethereum checksummed address>",
   "type": "NEW_CONFIRMATION",
   "owner": "<Ethereum checksummed address>",
@@ -79,6 +84,7 @@ Some parameters are common to every event:
 
 ```json
 {
+  "timestamp": "<int>",
   "address": "<Ethereum checksummed address>",
   "type": "PENDING_MULTISIG_TRANSACTION",
   "safeTxHash": "<0x-prefixed-hex-string>",
@@ -92,9 +98,23 @@ Some parameters are common to every event:
 
 ```json
 {
+  "timestamp": "<int>",
   "address": "<Ethereum checksummed address>",
   "type": "DELETED_MULTISIG_TRANSACTION",
   "safeTxHash": "<0x-prefixed-hex-string>",
+  "chainId": "<stringified-int>"
+}
+```
+
+### Module transaction
+
+```json
+{
+  "timestamp": "<int>",
+  "address": "<Ethereum checksummed address>",
+  "type": "MODULE_TRANSACTION",
+  "module": "<Ethereum checksummed address>",
+  "txHash": "<0x-prefixed-hex-string>",
   "chainId": "<stringified-int>"
 }
 ```
@@ -103,6 +123,8 @@ Some parameters are common to every event:
 
 ```json
 {
+  "id": "i<txHash-no-0x><traceAddress>",
+  "timestamp": "<int>",
   "address": "<Ethereum checksummed address>",
   "type": "INCOMING_ETHER" | "OUTGOING_ETHER",
   "txHash": "<0x-prefixed-hex-string>",
@@ -111,10 +133,17 @@ Some parameters are common to every event:
 }
 ```
 
+- `id`: Per-transfer unique identifier. For ether transfers it is `i` + `txHash` (without the
+  `0x` prefix) + `traceAddress`. The same `id` is shared by the `INCOMING_ETHER` and
+  `OUTGOING_ETHER` events of the same on-chain transfer, so it is unique per transfer-within-tx,
+  not per event.
+
 ### Incoming/Outgoing token (ERC20)
 
 ```json
 {
+  "id": "e<txHash-no-0x><logIndex>",
+  "timestamp": "<int>",
   "address": "<Ethereum checksummed address>",
   "type": "INCOMING_TOKEN" | "OUTGOING_TOKEN",
   "tokenAddress": "<Ethereum checksummed address>",
@@ -125,10 +154,16 @@ Some parameters are common to every event:
 }
 ```
 
+- `id`: Per-transfer unique identifier. For token transfers it is `e` + `txHash` (without the
+  `0x` prefix) + `logIndex`. The same `id` is shared by the `INCOMING_TOKEN` and `OUTGOING_TOKEN`
+  events of the same on-chain transfer, so it is unique per transfer-within-tx, not per event.
+
 ### Incoming/Outgoing tokens (ERC721)
 
 ```json
 {
+  "id": "e<txHash-no-0x><logIndex>",
+  "timestamp": "<int>",
   "address": "<Ethereum checksummed address>",
   "type": "INCOMING_TOKEN" | "OUTGOING_TOKEN",
   "tokenAddress": "<Ethereum checksummed address>",
@@ -139,10 +174,15 @@ Some parameters are common to every event:
 }
 ```
 
+- `id`: Per-transfer unique identifier. For token transfers it is `e` + `txHash` (without the
+  `0x` prefix) + `logIndex`. The same `id` is shared by the `INCOMING_TOKEN` and `OUTGOING_TOKEN`
+  events of the same on-chain transfer, so it is unique per transfer-within-tx, not per event.
+
 ### Message created/confirmed
 
 ```json
 {
+  "timestamp": "<int>",
   "address": "<Ethereum checksummed address>",
   "type": "MESSAGE_CREATED" | "MESSAGE_CONFIRMATION",
   "messageHash": "<0x-prefixed-hex-string>",


### PR DESCRIPTION
Follow-up to PLA-1607 and PLA-1707. Documents the new event fields in the README now that they ship from the transaction service.

Related to https://github.com/safe-global/safe-transaction-service/pull/2926

## Changes

- Added a note on `timestamp` (Unix epoch integer, seconds) to the common-params section, listing which events do **not** carry it (`EXECUTED_MULTISIG_TRANSACTION`, `SAFE_CREATED`, `REORG_DETECTED`, delegate events).
- PLA-1607 — transfer `timestamp` + `id`:
  - `INCOMING_ETHER`/`OUTGOING_ETHER`: `id` = `i` + txHash (no `0x`) + traceAddress.
  - `INCOMING_TOKEN`/`OUTGOING_TOKEN` (ERC20 + ERC721): `id` = `e` + txHash (no `0x`) + logIndex.
  - Noted `id` is shared across the incoming/outgoing pair of the same transfer.
- PLA-1707 — `timestamp` on `NEW_CONFIRMATION`, `PENDING_MULTISIG_TRANSACTION`, `DELETED_MULTISIG_TRANSACTION`, `MESSAGE_CREATED`, `MESSAGE_CONFIRMATION`, and `MODULE_TRANSACTION`.
- Added a full `MODULE_TRANSACTION` section — it was previously undocumented.

Docs only, no code changes.
