### PR TITLE
Remove deprecated failed field from EXECUTED_MULTISIG_TRANSACTION docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,15 +70,11 @@ ones) and is documented per event below.
   "safeTxHash": "<0x-prefixed-hex-string>",
   "to": "<Ethereum checksummed address>",
   "data": "<0x-prefixed-hex-string>" | null,
-  "failed": "true" | "false",
   "isFailed": true | false,
   "txHash": "<0x-prefixed-hex-string>",
   "chainId": "<stringified-int>"
 }
 ```
-
-> **Deprecation:** `failed` is a stringified boolean (`"true"`/`"false"`) kept only for
-> backwards compatibility and will be removed. Use the boolean `isFailed` instead.
 
 ### MultisigTransaction (proposed, not executed)
 


### PR DESCRIPTION
## What

The deprecated stringified `failed` field (`"true"`/`"false"`) has been removed from the `EXECUTED_MULTISIG_TRANSACTION` webhook payload in safe-transaction-service. This updates the README to match: drop the `failed` line and its deprecation note, keep the boolean `isFailed`.

## Why

The payload only sends `isFailed` (boolean) now. The docs should not advertise a field that no longer exists.
