### PR TITLE
feat: add EVENTS_LOG_ENABLED to disable per-event logging

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -21,3 +21,4 @@ ADMIN_WEBHOOK_AUTH=super-secret-token
 # WEBHOOK_FAILURE_THRESHOLD=90  # Failure rate percentage to trigger auto-disable (default: 90)
 # WEBHOOK_HEALTH_MINUTES_WINDOW=60  # Rolling window in minutes for webhook health stats (default: 60)
 # LOG_LEVEL=log  # Logging level: trace, debug, log, info, warn, error, fatal (default: log)
+# EVENTS_LOG_ENABLED=true  # Log one line per incoming event. Set to false to cut log volume (default: true)

--- a/src/modules/events/events.service.spec.ts
+++ b/src/modules/events/events.service.spec.ts
@@ -3,6 +3,7 @@ import { EventsService } from './events.service';
 import { QueueProvider } from '../../datasources/queue/queue.provider';
 import { TxServiceEventType } from './event.dto';
 import { Logger } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
 import { WebhookDispatcherService } from '../webhook/webhookDispatcher.service';
 
 describe('EventsService', () => {
@@ -16,7 +17,7 @@ describe('EventsService', () => {
 
   /* eslint-enable @typescript-eslint/no-unused-vars */
 
-  beforeEach(async () => {
+  async function buildService() {
     const webhookDispatcherServiceMock = {
       postEveryWebhook: async () => ({
         data: {},
@@ -25,6 +26,7 @@ describe('EventsService', () => {
       }),
     };
     const module = await Test.createTestingModule({
+      imports: [ConfigModule.forRoot()],
       providers: [EventsService, QueueProvider, WebhookDispatcherService],
     })
       .overrideProvider(QueueProvider)
@@ -37,6 +39,15 @@ describe('EventsService', () => {
     webhookDispatcherService = module.get<WebhookDispatcherService>(
       WebhookDispatcherService,
     );
+  }
+
+  beforeEach(async () => {
+    await buildService();
+  });
+
+  afterEach(() => {
+    delete process.env.EVENTS_LOG_ENABLED;
+    jest.restoreAllMocks();
   });
 
   describe('listenToEvents', () => {
@@ -96,6 +107,54 @@ describe('EventsService', () => {
           event: notJson,
           error: expect.stringContaining('JSON'),
         },
+      });
+    });
+
+    it('should not log the event when EVENTS_LOG_ENABLED is false', async () => {
+      process.env.EVENTS_LOG_ENABLED = 'false';
+      await buildService();
+      const postEveryWebhook = jest.spyOn(
+        webhookDispatcherService,
+        'postEveryWebhook',
+      );
+      const pushEventToEventsObservable = jest.spyOn(
+        eventsService,
+        'pushEventToEventsObservable',
+      );
+      const loggerSpy = jest.spyOn(Logger.prototype, 'log');
+      const msg = {
+        chainId: '1',
+        type: 'SAFE_CREATED' as TxServiceEventType,
+        address: '0x0275FC2adfF11270F3EcC4D2F7Aa0a9784601Ca6',
+      };
+
+      await eventsService.processEvent(JSON.stringify(msg));
+      expect(loggerSpy).not.toHaveBeenCalled();
+      // Webhook delivery must not be affected by the logging flag
+      expect(postEveryWebhook).toHaveBeenCalledTimes(1);
+      expect(postEveryWebhook).toHaveBeenCalledWith(msg);
+      expect(pushEventToEventsObservable).toHaveBeenCalledTimes(1);
+    });
+
+    it('should always log errors regardless of EVENTS_LOG_ENABLED', async () => {
+      process.env.EVENTS_LOG_ENABLED = 'false';
+      await buildService();
+      const loggerErrorSpy = jest.spyOn(Logger.prototype, 'error');
+
+      await eventsService.processEvent('not-json');
+      expect(loggerErrorSpy).toHaveBeenCalledWith({
+        message: 'Cannot parse message as JSON',
+        messageContext: {
+          event: 'not-json',
+          error: expect.stringContaining('JSON'),
+        },
+      });
+
+      await eventsService.processEvent(JSON.stringify({ chainId: '1' }));
+      expect(loggerErrorSpy).toHaveBeenCalledWith({
+        message:
+          "Unsupported message. A valid message should have at least 'chainId' and 'type'",
+        messageContext: { event: JSON.stringify({ chainId: '1' }) },
       });
     });
   });

--- a/src/modules/events/events.service.ts
+++ b/src/modules/events/events.service.ts
@@ -1,5 +1,6 @@
 import { Observable, Subject, filter } from 'rxjs';
 import { Injectable, Logger, OnApplicationBootstrap } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { QueueProvider } from '../../datasources/queue/queue.provider';
 import { TxServiceEvent } from './event.dto';
 import {
@@ -11,11 +12,16 @@ import {
 export class EventsService implements OnApplicationBootstrap {
   private readonly logger = new Logger(EventsService.name);
   private eventsSubject = new Subject<MessageEvent<TxServiceEvent>>();
+  private readonly eventsLogEnabled: boolean;
 
   constructor(
     private readonly queueProvider: QueueProvider,
     private readonly webhookDispatcherService: WebhookDispatcherService,
-  ) {}
+    private readonly configService: ConfigService,
+  ) {
+    this.eventsLogEnabled =
+      this.configService.get('EVENTS_LOG_ENABLED', 'true') !== 'false';
+  }
 
   onApplicationBootstrap() {
     return this.listenToEvents();
@@ -73,12 +79,14 @@ export class EventsService implements OnApplicationBootstrap {
     let txServiceEvent: TxServiceEvent;
     try {
       txServiceEvent = JSON.parse(message);
-      this.logger.log({
-        message: 'Processing event',
-        messageContext: {
-          event: txServiceEvent,
-        },
-      });
+      if (this.eventsLogEnabled) {
+        this.logger.log({
+          message: 'Processing event',
+          messageContext: {
+            event: txServiceEvent,
+          },
+        });
+      }
     } catch (error) {
       this.logger.error({
         message: 'Cannot parse message as JSON',

--- a/src/modules/events/events.service.ts
+++ b/src/modules/events/events.service.ts
@@ -19,8 +19,12 @@ export class EventsService implements OnApplicationBootstrap {
     private readonly webhookDispatcherService: WebhookDispatcherService,
     private readonly configService: ConfigService,
   ) {
+    // Only an explicit `true` enables it; normalize so 'True'/'TRUE' count.
     this.eventsLogEnabled =
-      this.configService.get('EVENTS_LOG_ENABLED', 'true') !== 'false';
+      this.configService
+        .get<string>('EVENTS_LOG_ENABLED', 'true')
+        .trim()
+        .toLowerCase() === 'true';
   }
 
   onApplicationBootstrap() {


### PR DESCRIPTION
## What

Adds `EVENTS_LOG_ENABLED` to turn off the per-event log line without a code change or a `LOG_LEVEL` change that hides everything else.

Closes [PLA-1814](https://linear.app/safe-global/issue/PLA-1814/events-service-add-env-var-to-disable-per-event-logging).

## ⚠️ Depends on PLA-1813

This branch is stacked on top of [`feat: migrate logging to nestjs-pino`](https://github.com/safe-global/safe-events-service/pull/574) and its base is set to that branch, not `main`. **Merge PLA-1813 first**; this PR will then reset its base to `main` automatically.

If you review it before that lands, the diff shown against `main` will also include the pino migration. Use the base-branch diff instead.

## Changes

- `EVENTS_LOG_ENABLED` read once in the `EventsService` constructor via `ConfigService`, same pattern as `WEBHOOK_AUTO_DISABLE`.
- Gates only the `Processing event` line. Error paths (`Cannot parse message as JSON`, `Unsupported message`) and webhook delivery are untouched.
- Documented in `.env.sample`.